### PR TITLE
Add metrics export and automate results commits

### DIFF
--- a/.github/workflows/run-analysis.yml
+++ b/.github/workflows/run-analysis.yml
@@ -16,9 +16,18 @@ jobs:
         run: pip install -r requirements.txt
       - name: Run analysis
         run: python filter_analysis.py
-      - name: Upload plots
+      - name: Upload results
         uses: actions/upload-artifact@v4
         with:
           name: plots
-          path: results/*.png
+          path: results/**
           if-no-files-found: ignore
+      - name: Commit results
+        run: |
+          git config --global user.name 'github-actions'
+          git config --global user.email 'github-actions@github.com'
+          git add results
+          if ! git diff --cached --quiet; then
+            git commit -m "Update analysis results [skip ci]"
+            git push
+          fi

--- a/filter_analysis.py
+++ b/filter_analysis.py
@@ -382,3 +382,6 @@ if __name__ == "__main__":
     ])
     print("\n=== Combined Performance Metrics for All Recordings ===")
     print(df_all_metrics.to_string(index=False))
+    os.makedirs("results", exist_ok=True)
+    df_all_metrics.to_csv("results/performance.csv", index=False)
+


### PR DESCRIPTION
## Summary
- save combined metrics to `results/performance.csv`
- upload CSV in workflow artifacts and push new results to `main`

## Testing
- `python3.12 -m venv .venv && source .venv/bin/activate && pip install -r requirements.txt`
- `python filter_analysis.py`


------
https://chatgpt.com/codex/tasks/task_e_684214a228bc832394092513cd85c618