### PR TITLE
Enable per-file sensor offset

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ After alignment:
 2. **Edit `filter_analysis.py`** if needed:
    - Adjust `exclude_first_seconds` (default = `None`).
    - Update the `trim_seconds` dictionary for per-file start/end trimming.
+   - Optionally define per-file light-sensor offsets via the `sensor_offset`
+     dictionary (default = `16`).
 3. **Run**:
    ```
    python filter_analysis.py


### PR DESCRIPTION
## Summary
- support customizable sensor offset per recording
- apply 32 offset for `log_1626_93118`
- document `sensor_offset` usage

## Testing
- `pip3.12 install --break-system-packages --ignore-installed -r requirements.txt`
- `python3.12 filter_analysis.py`

------
https://chatgpt.com/codex/tasks/task_e_6842bebb8fdc832383f263fee0b9ed52