### PR TITLE
Expand scale search range for optimization

### DIFF
--- a/filter_analysis.py
+++ b/filter_analysis.py
@@ -153,7 +153,8 @@ def optimize_scaling(t, y_al, ext_idx, ref_range=None, k_range=None):
         r = np.linspace(-1.0, 1.0, 200)
         ref_range = mid + width * np.sign(r) * np.abs(r) ** 1.5
     if k_range is None:
-        k_range = np.linspace(0.8, 1.2, 100)
+        # Expanded scale search (0.5..1.5) with finer resolution
+        k_range = np.linspace(0.5, 1.5, 200)
 
     mask = ~np.isnan(t) & ~np.isnan(y_al)
 


### PR DESCRIPTION
## Summary
- enlarge default scaling range from 0.8-1.2 to 0.5-1.5
- double resolution to 200 grid points

## Testing
- `python3.12 -m pip install --break-system-packages --upgrade --force-reinstall --ignore-installed -r requirements.txt`
- `python3.12 filter_analysis.py`

------
https://chatgpt.com/codex/tasks/task_e_6842c1f4609c8323bfe09671eabdb41c