### PR TITLE
Improve automatic README updates

### DIFF
--- a/.github/workflows/run-analysis.yml
+++ b/.github/workflows/run-analysis.yml
@@ -29,7 +29,8 @@ jobs:
         run: |
           git config --global user.name 'github-actions'
           git config --global user.email 'github-actions@github.com'
-          git add results
+          git add -A results README.md
+          git add -f results/*.png
           if ! git diff --cached --quiet; then
             git commit -m "Update analysis results [skip ci]"
             git push

--- a/README.md
+++ b/README.md
@@ -209,23 +209,8 @@ Running the script creates a `results/` folder containing:
 The table and figures below are updated by the GitHub Actions workflow on every push that runs `filter_analysis.py`. The workflow regenerates `results/performance.csv` and all plots in `results/`, ensuring this section always reflects the latest CI analysis.
 
 <!-- RESULTS_TABLE_START -->
-| Filename       | Method   |    RMSE |     MAE |   Extrema_MAE |   Extrema_MAE_scaled |   MAPE_pk |   MAVE_vl |   Lag |   Ref_Angle |   Scale_k |   RMSE_scaled |   MAE_scaled |
-|:---------------|:---------|--------:|--------:|--------------:|---------------------:|----------:|----------:|------:|------------:|----------:|--------------:|-------------:|
-| log_1626_93118 | KF_inv   | 3.50013 | 2.72786 |       3.24046 |              1.82055 |   4.81845 |   1.78385 |    14 |     86.7324 |  1.29397  |       1.63688 |      1.1243  |
-| log_1626_93118 | SG       | 3.61859 | 2.75185 |       3.43375 |              1.75933 |   5.05427 |   1.93788 |     2 |     86.8341 |  1.29397  |       1.90762 |      1.27844 |
-| log_1626_93118 | KF_on_SG | 3.6728  | 2.76034 |       3.50694 |              1.67498 |   5.22371 |   1.92222 |     6 |     86.9135 |  1.29397  |       2.00796 |      1.34863 |
-| log_1618_76251 | KF_inv   | 2.47858 | 1.73186 |       3.42423 |              1.35454 |   2.27022 |   3.71274 |    19 |     94.418  |  0.876884 |       2.16629 |      1.36809 |
-| log_1618_76251 | SG       | 2.59131 | 1.90651 |       2.00123 |              1.57672 |   2.94572 |   1.7651  |     4 |     93.3878 |  0.886935 |       2.30534 |      1.48839 |
-| log_1618_76251 | KF_on_SG | 2.40439 | 1.80014 |       1.85107 |              1.89041 |   3.20227 |   1.51327 |    11 |     93.1637 |  0.88191  |       2.15722 |      1.39526 |
-| log_1622_64296 | KF_inv   | 3.13407 | 2.51597 |       2.41009 |              1.92347 |   2.38969 |   2.43168 |    10 |    106.716  |  0.91206  |       2.81522 |      1.99782 |
-| log_1622_64296 | SG       | 3.13703 | 2.46259 |       3.91841 |              3.6739  |   4.03643 |   3.79346 |    10 |    123.011  |  0.957286 |       2.8626  |      1.98251 |
-| log_1622_64296 | KF_on_SG | 3.09645 | 2.47268 |       4.08145 |              3.99556 |   4.63121 |   3.49934 |    12 |    127.293  |  0.962312 |       2.86606 |      2.00294 |
 <!-- RESULTS_TABLE_END -->
 
-![General 1618](results/General_log_1618_76251.png)
-![Detail 1618](results/Detail_log_1618_76251.png)
-![General 1622](results/General_log_1622_64296.png)
-![Detail 1622](results/Detail_log_1622_64296.png)
-![General 1626](results/General_log_1626_93118.png)
-![Detail 1626](results/Detail_log_1626_93118.png)
+<!-- RESULTS_PLOTS_START -->
+<!-- RESULTS_PLOTS_END -->
 

--- a/filter_analysis.py
+++ b/filter_analysis.py
@@ -221,6 +221,13 @@ if __name__ == "__main__":
         "log_1626_93118": 32.0,
     }
 
+    # Prepare results directory and remove old plots so removed recordings
+    # disappear from the repository on the next commit
+    os.makedirs("results", exist_ok=True)
+    for f in os.listdir("results"):
+        if f.lower().endswith(".png"):
+            os.remove(os.path.join("results", f))
+
     # Initialize a list to collect metrics for all files
     all_metrics = []
 
@@ -399,19 +406,42 @@ if __name__ == "__main__":
     os.makedirs("results", exist_ok=True)
     df_all_metrics.to_csv("results/performance.csv", index=False)
 
-    # Update README table between markers
+    # Update README results section
     try:
-        marker_start = "<!-- RESULTS_TABLE_START -->"
-        marker_end = "<!-- RESULTS_TABLE_END -->"
+        table_start = "<!-- RESULTS_TABLE_START -->"
+        table_end = "<!-- RESULTS_TABLE_END -->"
+        plots_start = "<!-- RESULTS_PLOTS_START -->"
+        plots_end = "<!-- RESULTS_PLOTS_END -->"
+
         with open("README.md", "r", encoding="utf-8") as f:
             lines = f.read().splitlines()
-        if marker_start in lines and marker_end in lines:
-            s = lines.index(marker_start)
-            e = lines.index(marker_end)
+
+        # Update performance table
+        if table_start in lines and table_end in lines:
+            s = lines.index(table_start)
+            e = lines.index(table_end)
             table_md = tabulate(df_all_metrics, headers="keys", tablefmt="pipe", showindex=False)
-            new_lines = lines[:s+1] + table_md.splitlines() + lines[e:]
-            with open("README.md", "w", encoding="utf-8") as f:
-                f.write("\n".join(new_lines) + "\n")
+            table_block = ["<details><summary>Performance Summary</summary>", ""] + table_md.splitlines() + ["</details>"]
+            lines = lines[:s+1] + table_block + lines[e:]
+
+        # Update plot subsections
+        if plots_start in lines and plots_end in lines:
+            s = lines.index(plots_start)
+            e = lines.index(plots_end)
+            file_sections = []
+            for fname in sorted(df_all_metrics['Filename'].unique()):
+                file_sections.extend([
+                    f"<details><summary>{fname}</summary>",
+                    "",
+                    f"![General {fname}](results/General_{fname}.png)",
+                    f"![Detail {fname}](results/Detail_{fname}.png)",
+                    "",
+                    "</details>"
+                ])
+            lines = lines[:s+1] + file_sections + lines[e:]
+
+        with open("README.md", "w", encoding="utf-8") as f:
+            f.write("\n".join(lines) + "\n")
     except Exception as exc:
-        print(f"Failed to update README table: {exc}")
+        print(f"Failed to update README results: {exc}")
 


### PR DESCRIPTION
## Summary
- automate README updates with tables and plots
- add markers for results table and plots
- commit updated README from CI
- clean old PNGs before running analysis
- force-add new plot images in CI

## Testing
- `python3.12 --version`
- `pip install -r requirements.txt`
- `python filter_analysis.py`


------
https://chatgpt.com/codex/tasks/task_e_68431f1729988323b06b8a9301f5ee1c