### PR TITLE
Add German README with language switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+<p align="right">
+  <a href="README.md"><img src="https://img.shields.io/badge/EN-English-blue?style=for-the-badge" alt="English"></a>
+  <a href="README_GR.md"><img src="https://img.shields.io/badge/GR-Deutsch-red?style=for-the-badge" alt="Deutsch"></a>
+</p>
+
 
 # Angle Sensor Filtering & Extremum Tracking
 

--- a/README_GR.md
+++ b/README_GR.md
@@ -1,0 +1,104 @@
+<p align="right">
+  <a href="README.md"><img src="https://img.shields.io/badge/EN-English-blue?style=for-the-badge" alt="English"></a>
+  <a href="README_GR.md"><img src="https://img.shields.io/badge/GR-Deutsch-red?style=for-the-badge" alt="Deutsch"></a>
+</p>
+
+
+# Winkelsensorfilterung und Extremumverfolgung
+
+## Übersicht
+Rohe Licht-Sensor-Arrays bieten einen lauten Einblick in die Ausrichtung des Traktors und des Traktors. Ziel ist es, diese kostengünstigen Messwerte zusammen mit der Fahrzeuggeschwindigkeit in ein stabiles Hitch-Winkel-Signal zu verwandeln. Ein hochwertiger Sensor liefert die Grundwahrheit, die zur Kalibrierung und Bewertung verwendet wird.
+Dieser Workflow ist geplant, anstatt feste spezifische Dateinamen zu kodieren, auf ** jede neue Aufzeichnung ** (CSV -Datei), die Sie bereitstellen. Solange jeder CSV denselben Spaltenkonventionen (linke/rechte Sensorsummen, eine Referenzwinkelsäule, eine Geschwindigkeitsspalte und ein Zeitstempel) folgt, gelten dieselbe Vorverarbeitungs-, Filter-, Ausrichtung- und Bewertungsschritte.
+
+Für aktuelle Metriken und Handlungen, die vom CI-Workflow erzeugt werden, siehe die
+[Neueste Ergebnisse] (#10-latest-Reseults) Abschnitt unten.
+
+## Hauptaufgabe
+
+Unser Ziel ist es, eine klare Beispielpipeline zu liefern, die:
+1. liest einen CSV aus "Aufzeichnungen/".
+2. leitet eine Hitch-Winkel-Schätzung aus den Licht-Sensor-Arrays ab.
+3. Reinigen Sie die Sensor- und Fahrzeuggeschwindigkeitsspalten.
+4. führt einen Geschwindigkeitsbewusstsein von Kalman-Filter und optionalen Alternativen aus.
+5. Ausrichtet das gefilterte Ergebnis mit den Metriken zur Referenz- und Protokollfehler.
+6. Speichert reproduzierbare Diagramme in "Ergebnissen/" zur Inspektion.
+
+Stellen Sie sich dieses Repository als Ausgangspunkt für Entwickler vor, um mit Filtermethoden zu experimentieren und Verbesserungen beizutragen.
+
+
+---
+
+## Verzeichnisstruktur
+
+`` `
+.
+├── Readme.md ← Diese Datei (generische Anweisungen)
+├── filter_analysis.py ← Python -Skript (Laden Sie CSV, Prozess, Diagramm, Metriken)
+├── Aufzeichnungen/ ← Platzieren Sie hier ein oder mehrere CSV -Aufnahmen
+│ ├── log_1618_76251.csv ← Beispielaufzeichnungsdatei
+│ ├── log_1622_64296.csv
+│ └── log_1626_93118.csv
+└── Ergebnisse/ ← automatisch generierte Zahlen und `Performance.csv`
+`` `
+
+- ** filter_analysis.py **: Enthält alle Code zum Laden, Vorverarbeitung, Filterung, Ausrichtung und Leistungsbewertung. Es verarbeitet automatisch jede CSV -Aufzeichnung ** im Ordner "Aufnahmen/".
+- ** Aufnahmen/**: Verzeichnis, in dem Sie jedes neue CSV -Protokoll platzieren. Jede Datei muss die folgenden Spalten mit den genauen deutschen Namen des Loggers enthalten:
+- `Durchschnitt_L_SE` and `Durchschnitt_L_Be_SE` – left light-sensor sums,
+- `Durchschnitt_R_SE` and `Durchschnitt_R_Be_SE` – right light-sensor sums,
+- `Deichsel_angle` - Drawbar (Hitch) Winkelreferenz,
+- `Geschwindigkeit` – vehicle speed,
+- `esp time` - Zeitstempel in Millisekunden.
+- Optional redundant sensors `Durchschnitt_L_SE2`, `Durchschnitt_L_Be_SE2`,
+`Durchschnitt_R_SE2`, and `Durchschnitt_R_Be_SE2` (all zeros when not used).
+- ** Ergebnisse/**: automatisch erstellt, wenn Sie das Skript ausführen. Hält PNG -Diagramme und eine Summary -Tabelle von `Performance.csv`.
+
+---
+
+## 1. Was wir erreichen wollen
+
+1. ** Berechnen Sie einen rohen Hitch -Winkel -Proxy ** aus linken/rechten Sensorsummen.
+2. ** Reinigen Sie die Zielreferenz ** Durch Interpolieren von Nulldropouts.
+3. ** Vorverarbeitungsgeschwindigkeit ** Durch das Ausschneiden negativer Werte, die Interpolation von Nullen (nur zwischen der ersten und letzten Bewegung) und ein kleines Rolling -Durchschnitt, um Jitter zu entfernen.
+4. ** Spikes ** aus dem rohen Proxy mit einem kausalen Hampelfilter (Fenster = 5) entfernen.
+5. ** Wenden Sie in Echtzeit einen Geschwindigkeitsbewusstsein von Kalman -Filter ** (KF_INV) an, bei dem der Prozessverhältnis mit 1/Geschwindigkeit skaliert wird.
+6. ** Erkennen Sie die lokalen Extrema (Peaks & Täler) ** im sauberen Referenzsignal, um zu quantifizieren, wie gut jeder Filter hohe/Tiefpunkte aufbewahrt.
+7. ** Ausrichtung ** Jede gefilterte Ausgabe auf die Referenz durch Übereinstimmung mit extremen Indizes, so dass Peak/Valley -Fehler zu den richtigen Zeitpunkten gemessen werden können.
+8. ** Berechnen Sie Metriken ** (RMSE, MAE, plus spezialisierte Extrema -Mae), um die Leistung zu bewerten.
+9. ** Testen Sie optional alternative Filter ** (z. B. Savitzky -Golay und Hybrid kf_on_sg) auf dieselben Aufzeichnungen und vergleichen die Ergebnisse.
+
+Da jede Aufzeichnungsdatei identische Spaltennamen/-muster verwendet, können Sie einfach neue CSVs in das Verzeichnis "Aufzeichnungen/" "fallen lassen und das Skript erneut ausführen.
+
+---
+
+## 2. Vorverarbeitungsschritte (einzelne Aufzeichnung)
+
+Wenn Sie das Analyseskript auf einer neuen Aufzeichnung ausführen:
+
+1. ** Laden Sie den CSV ** in einen Datenrahmen.
+2. ** Identifizieren Sie Spalten ** über ihre Spaltennamenmuster:
+- `Deichsel_angle` (Drawbar -Winkelreferenz).
+- `Geschwindigkeit` (speed).
+- `Durchschnitt_L_SE` and `Durchschnitt_L_Be_SE` (left light-sensor sums).
+- `Durchschnitt_R_SE` and `Durchschnitt_R_Be_SE` (right light-sensor sums).
+- Optional redundant sensors `Durchschnitt_L_SE2`, `Durchschnitt_L_Be_SE2`,
+`Durchschnitt_R_SE2`, and `Durchschnitt_R_Be_SE2`.
+3. ** Berechnen Sie den rohen Proxy **:
+- Das Skript prüft automatisch, ob die redundanten Sensorspalten eine enthalten
+Werte ungleich Null. Wenn dies der Fall ist, umfassen die linken und rechten Summen alle vier
+Sensoren pro Seite und eine Konstante von "32" werden hinzugefügt. Wenn die redundanten Spalten
+sind alle Null, die Datei wird angenommen, dass sie nur zwei Sensoren pro Seite und a verwenden
+Konstante von `` 16``:
+`` `
+# Ohne redundante Sensoren
+L = (l_se + l_be_se) + 16
+R = (r_se + r_be_se) + 16
+
+# Mit redundanten Sensoren
+L = (l_se + l_se2 + l_be_se + l_be_se2) + 32
+R = (r_se + r_se2 + r_be_se + r_be_se2) + 32
+`` `
+- Der Rohwinkel -Proxy ist dann
+`` `
+RAW = 90 + (((l + r) / 2) * (l - r)) / (l * r) * 100
+`` `
+*(Diese Übersetzung ist unvollständig. Weitere Abschnitte folgen.)*

--- a/filter_analysis.py
+++ b/filter_analysis.py
@@ -418,35 +418,41 @@ if __name__ == "__main__":
         plots_start = "<!-- RESULTS_PLOTS_START -->"
         plots_end = "<!-- RESULTS_PLOTS_END -->"
 
-        with open("README.md", "r", encoding="utf-8") as f:
-            lines = f.read().splitlines()
+        def update_readme(path: str) -> None:
+            with open(path, "r", encoding="utf-8") as f:
+                lines = f.read().splitlines()
 
-        # Update performance table
-        if table_start in lines and table_end in lines:
-            s = lines.index(table_start)
-            e = lines.index(table_end)
-            table_md = tabulate(df_all_metrics, headers="keys", tablefmt="pipe", showindex=False)
-            table_block = ["<details><summary>Performance Summary</summary>", ""] + table_md.splitlines() + ["</details>"]
-            lines = lines[:s+1] + table_block + lines[e:]
+            # Update performance table
+            if table_start in lines and table_end in lines:
+                s = lines.index(table_start)
+                e = lines.index(table_end)
+                table_md = tabulate(df_all_metrics, headers="keys", tablefmt="pipe", showindex=False)
+                table_block = ["<details><summary>Performance Summary</summary>", ""] + table_md.splitlines() + ["</details>"]
+                lines = lines[:s+1] + table_block + lines[e:]
 
-        # Update plot subsections
-        if plots_start in lines and plots_end in lines:
-            s = lines.index(plots_start)
-            e = lines.index(plots_end)
-            file_sections = []
-            for fname in sorted(df_all_metrics['Filename'].unique()):
-                file_sections.extend([
-                    f"<details><summary>{fname}</summary>",
-                    "",
-                    f"![General {fname}](results/General_{fname}.png)",
-                    f"![Detail {fname}](results/Detail_{fname}.png)",
-                    "",
-                    "</details>"
-                ])
-            lines = lines[:s+1] + file_sections + lines[e:]
+            # Update plot subsections
+            if plots_start in lines and plots_end in lines:
+                s = lines.index(plots_start)
+                e = lines.index(plots_end)
+                file_sections = []
+                for fname in sorted(df_all_metrics['Filename'].unique()):
+                    file_sections.extend([
+                        f"<details><summary>{fname}</summary>",
+                        "",
+                        f"![General {fname}](results/General_{fname}.png)",
+                        f"![Detail {fname}](results/Detail_{fname}.png)",
+                        "",
+                        "</details>"
+                    ])
+                lines = lines[:s+1] + file_sections + lines[e:]
 
-        with open("README.md", "w", encoding="utf-8") as f:
-            f.write("\n".join(lines) + "\n")
+            with open(path, "w", encoding="utf-8") as f:
+                f.write("\n".join(lines) + "\n")
+
+        # Update both English and German READMEs
+        for readme in ["README.md", "README_GR.md"]:
+            if os.path.exists(readme):
+                update_readme(readme)
     except Exception as exc:
         print(f"Failed to update README results: {exc}")
 


### PR DESCRIPTION
## Summary
- add switch badges to switch between EN/GR READMEs
- translate the intro of README into German
- update script to update both README files automatically

## Testing
- `python3.12 -m pip install --break-system-packages --ignore-installed -r requirements.txt`
- `python3.12 filter_analysis.py` *(interrupted after partial processing)*

------
https://chatgpt.com/codex/tasks/task_e_684887c365148323839dfe84d70162b7